### PR TITLE
Invoke ctags recursively

### DIFF
--- a/src/main/scala/com/kalmanb/sbt/CtagsPlugin.scala
+++ b/src/main/scala/com/kalmanb/sbt/CtagsPlugin.scala
@@ -158,7 +158,7 @@ class CtagsPlugin extends Plugin {
    * or a different indexer is used
    */
   def updateCtags(baseDirectory: File): Unit = {
-    "ctags" !
+    "ctags -R" !
   }
 
   import Project._


### PR DESCRIPTION
As discussed on the previous issue, on Linux with exuberant-ctags is necessary this flag.
